### PR TITLE
Working rocket example code

### DIFF
--- a/acado.pxd
+++ b/acado.pxd
@@ -97,15 +97,14 @@ cdef extern from 'acado/symbolic_expression/variable_types.hpp' namespace 'ACADO
 cdef extern from 'acado/function/function_.hpp' namespace 'ACADO':
     cdef cppclass Function:
         Function()
+        Function(const Function&)
 
         Function& operator<< (const Expression&)
-
 
         int getDim()
         int getN()
         int getNX()
         int getNU()
-
 
         BooleanType isConvex()
 
@@ -113,11 +112,12 @@ cdef extern from 'acado/function/differential_equation.hpp' namespace 'ACADO':
 
     cdef cppclass DifferentialEquation(Function):
         DifferentialEquation()
+        DifferentialEquation(const DifferentialEquation&)
         DifferentialEquation(const double &tStart, const double &tEnd )
         DifferentialEquation(const double &tStart, const Parameter &tEnd )
 
-        DifferentialEquation& operator<<( const Expression&)
-        DifferentialEquation& operator==( const Expression&)
+        DifferentialEquation& operator==(const Expression&)
+        #DifferentialEquation& operator<<(const Expression&)
 
 cdef extern from 'acado/utils/acado_types.hpp' namespace 'ACADO':
 

--- a/acado.pxd
+++ b/acado.pxd
@@ -1,6 +1,7 @@
 from libcpp cimport bool
 from libcpp.string cimport string
 
+
 cdef extern from 'acado/utils/acado_types.hpp' namespace 'ACADO':
     ctypedef bool BooleanType
 
@@ -59,6 +60,10 @@ cdef extern from 'acado/symbolic_expression/expression.hpp' namespace 'ACADO':
         Expression(const Expression&)
         Expression(string&, unsigned int , unsigned int)
 
+        unsigned int getDim()
+        unsigned int getNumRows()
+        unsigned int getNumCols()
+        bool isVariable() 
 
         Expression operator+ (Expression&)
         Expression operator- (Expression&)
@@ -68,9 +73,6 @@ cdef extern from 'acado/symbolic_expression/expression.hpp' namespace 'ACADO':
         ConstraintComponent operator<= (const double&)
         ConstraintComponent operator>= (const double&)
         ConstraintComponent operator== (const double&)
-
-        Expression getExp()
-        Expression getDot()
 
     cdef cppclass ExpressionType[Derived,Type, AllowCounter](Expression):
         ExpressionType()
@@ -93,6 +95,13 @@ cdef extern from 'acado/symbolic_expression/variable_types.hpp' namespace 'ACADO
     cdef cppclass Parameter(ExpressionType):
         Parameter()
 
+    cdef cppclass IntermediateState(ExpressionType):
+        IntermediateState() 
+
+cdef extern from 'acado/symbolic_expression/acado_syntax.hpp':
+    returnValue clearAllStaticCounters()
+    IntermediateState exp(const Expression&)
+    Expression dot(const Expression& )
 
 cdef extern from 'acado/function/function_.hpp' namespace 'ACADO':
     cdef cppclass Function:
@@ -169,3 +178,8 @@ cdef extern from 'acado/optimization_algorithm/optimization_algorithm.hpp' names
         returnValue set(OptionsName, int) except+ # from options.hpp
         returnValue set(OptionsName, double) except+ # from options.hpp
         returnValue set(OptionsName, string) except+ # from options.hpp
+
+cdef extern from "<iostream>" namespace "std":
+    cdef cppclass ostream:
+        ostream& operator<< (Expression&)
+    ostream cout

--- a/acado.pxd
+++ b/acado.pxd
@@ -50,6 +50,12 @@ cdef extern from 'acado/symbolic_expression/constraint_component.hpp' namespace 
         ConstraintComponent()
         ConstraintComponent(const ConstraintComponent)
 
+        Expression getExpression()
+
+        ConstraintComponent operator<= (const double&)
+        ConstraintComponent operator>= (const double&)
+        ConstraintComponent operator== (const double&)
+
 cdef extern from 'acado/symbolic_expression/expression.hpp' namespace 'ACADO':
 
     cdef cppclass Expression:
@@ -151,6 +157,12 @@ cdef extern from 'acado/utils/acado_types.hpp' namespace 'ACADO':
         GAUSS_NEWTON_WITH_BLOCK_BFGS
         EXACT_HESSIAN
         DEFAULT_HESSIAN_APPROXIMATION
+    
+    cdef enum PrintScheme:
+        PS_DEFAULT
+        PS_PLAIN
+        PS_MATLAB
+        PS_MATLAB_BINARY
 
 cdef extern from 'acado/ocp/ocp.hpp' namespace 'ACADO':
 
@@ -167,6 +179,19 @@ cdef extern from 'acado/ocp/ocp.hpp' namespace 'ACADO':
         returnValue subjectTo( const DifferentialEquation&)
         returnValue subjectTo( int, const ConstraintComponent&)
 
+cdef extern from "<iostream>" namespace "std":
+    cdef cppclass ostream:
+        ostream& operator<< (Expression&)
+        ostream& operator<< (Function&)
+        ostream& operator<< (VariablesGrid&)
+    ostream cout
+
+cdef extern from 'acado/variables_grid/variables_grid.hpp' namespace 'ACADO':
+    cdef cppclass VariablesGrid:
+        VariablesGrid()
+        VariablesGrid(const VariablesGrid&)
+        returnValue pprint "print"(ostream&, const char*, PrintScheme)
+
 cdef extern from 'acado/optimization_algorithm/optimization_algorithm.hpp' namespace 'ACADO':
 
     cdef cppclass OptimizationAlgorithm:
@@ -179,7 +204,6 @@ cdef extern from 'acado/optimization_algorithm/optimization_algorithm.hpp' names
         returnValue set(OptionsName, double) except+ # from options.hpp
         returnValue set(OptionsName, string) except+ # from options.hpp
 
-cdef extern from "<iostream>" namespace "std":
-    cdef cppclass ostream:
-        ostream& operator<< (Expression&)
-    ostream cout
+        returnValue getDifferentialStates(VariablesGrid&)
+        returnValue getParameters(VariablesGrid&)
+        returnValue getControls(VariablesGrid&)

--- a/acadopy.pxd
+++ b/acadopy.pxd
@@ -46,6 +46,8 @@ cdef class OCP:
     cdef acado.OCP* _thisptr
     cdef bool _owner
 
+cdef class VariablesGrid:
+    cdef acado.VariablesGrid* _thisptr
 
 cdef class OptimizationAlgorithm:
     cdef acado.OptimizationAlgorithm* _thisptr

--- a/examples/rocket_flight_control.py
+++ b/examples/rocket_flight_control.py
@@ -31,8 +31,10 @@ t_end = 10.0
 # An implementation of the model equations for the rocket
 # !! The following should be evaluated a <<, giving a DifferentialEquation, then == which is still a DifferentialEquation
 f << dot(s) == v
-f << dot(v) == ((u - 0.2 * v * v) / m)
-f << dot(m) == (-0.01 * u * u) 
+f << dot(v) == (u - 0.2 * v * v) / m
+f << dot(m) == -0.01 * u * u
+
+print(f)
 
 ########################################
 # Define an optimal control problem
@@ -67,3 +69,15 @@ algorithm.set(KKT_TOLERANCE, 1e-10 )
 
 algorithm.solve()
 
+print('Get states')
+states = algorithm.get_differential_states()
+print('Get controls')
+controls = algorithm.get_controls()
+
+print(states)
+states.pprint()
+
+print(controls)
+controls.pprint()
+
+#parameters.pprint()

--- a/examples/rocket_flight_control.py
+++ b/examples/rocket_flight_control.py
@@ -29,12 +29,9 @@ t_end = 10.0
 ########################################
 
 # An implementation of the model equations for the rocket
-# !! The following should be evaluated a <<, giving a DifferentialEquation, then == which is still a DifferentialEquation
 f << dot(s) == v
 f << dot(v) == (u - 0.2 * v * v) / m
 f << dot(m) == -0.01 * u * u
-
-print(f)
 
 ########################################
 # Define an optimal control problem
@@ -69,15 +66,8 @@ algorithm.set(KKT_TOLERANCE, 1e-10 )
 
 algorithm.solve()
 
-print('Get states')
 states = algorithm.get_differential_states()
-print('Get controls')
 controls = algorithm.get_controls()
 
 print(states)
-states.pprint()
-
 print(controls)
-controls.pprint()
-
-#parameters.pprint()

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 from setuptools import setup, Extension
 from Cython.Distutils import build_ext
 
-import eigency
-
 setup(
     name='acadopy',
     version=1.0,

--- a/test_acado.py
+++ b/test_acado.py
@@ -2,11 +2,14 @@ import unittest
 
 from acadopy import (
     Expression, DifferentialState, IntermediateState, TIME, Function,
-    exp, DMatrix, DVector
+    exp, DMatrix, DVector, clear_static_counters
 )
 
 
 class AcadoTestCase(unittest.TestCase):
+
+    def setUp(self):
+        clear_static_counters()
 
     def test_instantiate_expression(self):
 
@@ -23,9 +26,15 @@ class AcadoTestCase(unittest.TestCase):
         e = Expression("name", 3, 1)
         self.assertIsInstance(e, Expression)
 
+    def test_expression_print(self):
+
+        e = Expression("name", 3, 1)
+        print(e)
+
     def test_instantiate_function(self):
 
         f = Function()
+
 
     def test_expression_add(self):
 
@@ -34,10 +43,24 @@ class AcadoTestCase(unittest.TestCase):
         y = x + 0.5
 
         self.assertIsInstance(y, Expression)
+        self.assertEqual(y.dim, 1)
+        self.assertEqual(y.num_rows, 1)
+        self.assertEqual(y.num_cols, 1)
+        self.assertFalse(y.is_variable)
 
         y = 0.5 + x 
 
         self.assertIsInstance(y, Expression)
+
+        z = DifferentialState()
+
+        y = x + z + 1.0
+        print(y)
+        self.assertIsInstance(y, Expression)
+        self.assertEqual(y.dim, 1)
+        self.assertEqual(y.num_rows, 1)
+        self.assertEqual(y.num_cols, 1)
+        self.assertFalse(y.is_variable)
 
     def test_expression_mult(self):
 
@@ -69,11 +92,9 @@ class AcadoTestCase(unittest.TestCase):
         self.assertEqual(f.nx, 0)
 
         f << expression
+
         self.assertEqual(f.dim, 1)
         self.assertEqual(f.nx, 1)
-
-
-
 
     def test_simple_function(self):
         x = DifferentialState()

--- a/test_acado.py
+++ b/test_acado.py
@@ -65,7 +65,15 @@ class AcadoTestCase(unittest.TestCase):
 
         expression = exp(x + 1)
 
+        self.assertEqual(f.dim, 0)
+        self.assertEqual(f.nx, 0)
+
         f << expression
+        self.assertEqual(f.dim, 1)
+        self.assertEqual(f.nx, 1)
+
+
+
 
     def test_simple_function(self):
         x = DifferentialState()

--- a/test_acado.py
+++ b/test_acado.py
@@ -2,7 +2,8 @@ import unittest
 
 from acadopy import (
     Expression, DifferentialState, IntermediateState, TIME, Function,
-    exp, DMatrix, DVector, clear_static_counters
+    exp, DMatrix, DVector, clear_static_counters, dot, DifferentialEquation,
+    ConstraintComponent
 )
 
 
@@ -80,6 +81,10 @@ class AcadoTestCase(unittest.TestCase):
         z = exp(x)
 
         self.assertIsInstance(z, Expression)
+        self.assertEqual(z.dim, 1)
+        self.assertEqual(z.num_rows, 1)
+        self.assertEqual(z.num_cols, 1)
+        self.assertFalse(z.is_variable)
 
     def test_function_loading_expression(self):
 
@@ -103,6 +108,34 @@ class AcadoTestCase(unittest.TestCase):
         f= Function()
 
         z = 0.5 * x + 1.0
+
+    def test_differentialstate_equal(self):
+
+        f = DifferentialEquation()
+        s = DifferentialState()
+        v = DifferentialState()
+
+        intermediate = f << dot(s)
+
+        self.assertIsInstance(intermediate, DifferentialEquation)
+        self.assertEqual(intermediate.dim, 0)
+        self.assertEqual(intermediate.n, 0)
+        self.assertEqual(intermediate.nx, 0)
+        self.assertEqual(intermediate.nu, 0)
+
+        self.assertIsInstance(f, DifferentialEquation)
+        self.assertEqual(f.dim, 0)
+        self.assertEqual(f.n, 0)
+        self.assertEqual(f.nx, 0)
+        self.assertEqual(f.nu, 0)
+
+        result = f == v
+
+        self.assertIsInstance(result, DifferentialEquation)
+        self.assertEqual(result.dim, 1)
+        self.assertEqual(result.n, 0)
+        self.assertEqual(result.nx, 2)
+        self.assertEqual(result.nu, 0)
 
     def test_dmatrix(self):
         
@@ -133,3 +166,14 @@ class AcadoTestCase(unittest.TestCase):
         self.assertIsInstance(vector, DVector)
 
        
+    def test_constraint_component_le(self):
+
+        v = DifferentialState()
+
+        result = -0.01 <= v
+
+        self.assertIsInstance(result, ConstraintComponent)
+
+        result = result <= 3.0
+
+        self.assertIsInstance(result, ConstraintComponent)


### PR DESCRIPTION
@ml-evs this is working on os-x and rh6. It's still full of things to clean up but gives a good place to start.

Current output:

```
(edm)DP-MBP:acadopy dpinte (fix/function-lshift-issue) $ python -m unittest discover
('ConstraintComponent.__le__', <type 'acadopy.ConstraintComponent'>, <type 'float'>)
.......[ ((xd[0]+xd[1])+(real_t)(1))]
....[ (real_t)(0) , (real_t)(0) , (real_t)(0)]
.....
----------------------------------------------------------------------
Ran 16 tests in 0.002s

OK
(edm)DP-MBP:acadopy dpinte (fix/function-lshift-issue) $ python examples/rocket_flight_control.py

ACADO Toolkit::SCPmethod -- A Sequential Quadratic Programming Algorithm.
Copyright (C) 2008-2014 by Boris Houska, Hans Joachim Ferreau,
Milan Vukov, Rien Quirynen, KU Leuven.
Developed within the Optimization in Engineering Center (OPTEC)
under supervision of Moritz Diehl. All rights reserved.

ACADO Toolkit is distributed under the terms of the GNU Lesser
General Public License 3 in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
GNU Lesser General Public License for more details.

sqp it | qp its |       kkt tol |       obj val |     merit val |      ls param |
     1 |      0 |  6.050915e+00 |  0.000000e+00 |  2.582585e+00 |  1.000000e+00 |
     2 |      0 |  1.967140e+00 |  1.208804e+00 |  2.118808e+00 |  1.000000e+00 |
     3 |      0 |  7.269393e-01 |  1.934326e+00 |  1.936027e+00 |  1.000000e+00 |
     4 |      0 |  7.908669e-04 |  1.935109e+00 |  1.935118e+00 |  1.000000e+00 |
     5 |      0 |  6.514811e-06 |  1.935115e+00 |  1.935115e+00 |  1.000000e+00 |
     6 |      0 |  4.803896e-08 |  1.935115e+00 |  1.935115e+00 |  1.000000e+00 |
     7 |      0 |  4.631624e-10 |  1.935115e+00 |  1.935115e+00 |  1.000000e+00 |
     8 |      0 |  2.096648e-11 |  1.935115e+00 |  1.935115e+00 |  1.000000e+00 |

Covergence achieved. Demanded KKT tolerance is 1.000000e-10.

[	0.0000000000000000e+00	0.0000000000000000e+00	0.0000000000000000e+00	1.0000000000000000e+00	0.0000000000000000e+00	]
[	5.0000000000000000e-01	8.8250395645490282e-02	3.5108268303022566e-01	9.9748250972590591e-01	2.5174902740940308e-01	]
[	1.0000000000000000e+00	3.3628669455855897e-01	6.3642411837452006e-01	9.9556494082260583e-01	4.4350591773941650e-01	]
[	1.5000000000000000e+00	7.1185983168580202e-01	8.6029842348132357e-01	9.9400196547469288e-01	5.9980345253070511e-01	]
[	2.0000000000000000e+00	1.1858327181054804e+00	1.0302320230212771e+00	9.9266133049220073e-01	7.3386695077992736e-01	]
[	2.5000000000000000e+00	1.7333766795362875e+00	1.1553701640727263e+00	9.9146865625037395e-01	8.5313437496263078e-01	]
[	3.0000000000000000e+00	2.3343112619347699e+00	1.2447746600317560e+00	9.9038184469859480e-01	9.6181553014052690e-01	]
[	3.5000000000000000e+00	2.9727384193536301e+00	1.3063024160203971e+00	9.8937856082449738e-01	1.0621439175502847e+00	]
[	4.0000000000000000e+00	3.6362795531701413e+00	1.3460909633454079e+00	9.8844996098451232e-01	1.1550039015487752e+00	]
[	4.5000000000000000e+00	4.3151673149511902e+00	1.3684409020966493e+00	9.8759759251810453e-01	1.2402407481895525e+00	]
[	5.0000000000000000e+00	5.0013323330486683e+00	1.3758760765107947e+00	9.8683186006087054e-01	1.3168139939129797e+00	]
[	5.5000000000000000e+00	5.6875320997976706e+00	1.3692300382425355e+00	9.8617089352185050e-01	1.3829106478149775e+00	]
[	6.0000000000000000e+00	6.3665125374812508e+00	1.3476780544676734e+00	9.8563846214363104e-01	1.4361537856369457e+00	]
[	6.5000000000000000e+00	7.0301680827259307e+00	1.3086901010516896e+00	9.8525886632221404e-01	1.4741133677786358e+00	]
[	7.0000000000000000e+00	7.6686679520498835e+00	1.2479300028621454e+00	9.8504567439807789e-01	1.4954325601922858e+00	]
[	7.5000000000000000e+00	8.2695449328770270e+00	1.1591834365970084e+00	9.8498053439480970e-01	1.5019465605190949e+00	]
[	8.0000000000000000e+00	8.8168038860192777e+00	1.0344697734632160e+00	9.8498036454503135e-01	1.5019635454969211e+00	]
[	8.5000000000000000e+00	9.2902012092117605e+00	8.6456008297550480e-01	9.8486034588984572e-01	1.5139654110154901e+00	]
[	9.0000000000000000e+00	9.6649501131481923e+00	6.4011212078455448e-01	9.8431981789804657e-01	1.5680182101953983e+00	]
[	9.5000000000000000e+00	9.9121423509984901e+00	3.5339958280031047e-01	9.8299980868798831e-01	1.7000191312012203e+00	]
[	1.0000000000000000e+01	1.0000000000000000e+01	-4.5941239636154362e-24	9.8064884793998441e-01	1.9351152060015873e+00	]

[	0.0000000000000000e+00	7.0957596832108616e-01	]
[	5.0000000000000000e-01	6.1928489458409230e-01	]
[	1.0000000000000000e+00	5.5910202072840198e-01	]
[	1.5000000000000000e+00	5.1780980726367909e-01	]
[	2.0000000000000000e+00	4.8840029521429512e-01	]
[	2.5000000000000000e+00	4.6622131049083765e-01	]
[	3.0000000000000000e+00	4.4794729022455015e-01	]
[	3.5000000000000000e+00	4.3095239643953975e-01	]
[	4.0000000000000000e+00	4.1288460044127900e-01	]
[	4.5000000000000000e+00	3.9133935586247198e-01	]
[	5.0000000000000000e+00	3.6358397627508049e-01	]
[	5.5000000000000000e+00	3.2632234928662140e-01	]
[	6.0000000000000000e+00	2.7553432505476882e-01	]
[	6.5000000000000000e+00	2.0649064101626874e-01	]
[	7.0000000000000000e+00	1.1414026745030771e-01	]
[	7.5000000000000000e+00	-5.8283750445529241e-03	]
[	8.0000000000000000e+00	-1.5493137525091430e-01	]
[	8.5000000000000000e+00	-3.2879415803784667e-01	]
[	9.0000000000000000e+00	-5.1381109564863336e-01	]
[	9.5000000000000000e+00	-6.8570558521915514e-01	]
[	1.0000000000000000e+01	-6.8570558521915514e-01	]
```