### PR TITLE
[WIP] Add wrapper for MultiObjectiveOptimizer class and Pareto analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # acadopy
-Python bindings for the acado library
+Python bindings for the [acado.github.io](ACADO library), a toolkit for
+automatic control and dynamic optimization.
 
 
 ## Installation

--- a/acadopy/acado.pxd
+++ b/acadopy/acado.pxd
@@ -97,7 +97,7 @@ cdef extern from 'acado/symbolic_expression/variable_types.hpp' namespace 'ACADO
 
     cdef cppclass DifferentialState(ExpressionType):
         DifferentialState()
-        DifferentialState(string& , unsigned int, unsigned int)
+        DifferentialState(string&, unsigned int, unsigned int)
 
     cdef cppclass IntermediateState(ExpressionType):
         IntermediateState()
@@ -137,9 +137,10 @@ cdef extern from 'acado/function/differential_equation.hpp' namespace 'ACADO':
         DifferentialEquation(const DifferentialEquation&)
         DifferentialEquation(const double &tStart, const double &tEnd )
         DifferentialEquation(const double &tStart, const Parameter &tEnd )
+        DifferentialEquation(const Parameter &tStart, const double &tEnd )
+        DifferentialEquation(const Parameter &tStart, const Parameter &tEnd )
 
         DifferentialEquation& operator==(const Expression&)
-        #DifferentialEquation& operator<<(const Expression&)
 
 cdef extern from 'acado/utils/acado_types.hpp' namespace 'ACADO':
 

--- a/acadopy/acado.pxd
+++ b/acadopy/acado.pxd
@@ -162,6 +162,8 @@ cdef extern from 'acado/utils/acado_types.hpp' namespace 'ACADO':
         HESSIAN_APPROXIMATION
         MAX_NUM_ITERATIONS
         KKT_TOLERANCE
+        PARETO_FRONT_GENERATION
+        PARETO_FRONT_DISCRETIZATION
 
     cdef enum HessianApproximationMode:
         CONSTANT_HESSIAN
@@ -171,6 +173,16 @@ cdef extern from 'acado/utils/acado_types.hpp' namespace 'ACADO':
         GAUSS_NEWTON_WITH_BLOCK_BFGS
         EXACT_HESSIAN
         DEFAULT_HESSIAN_APPROXIMATION
+
+    cdef enum ParetoFrontGeneration:
+        PFG_FIRST_OBJECTIVE
+        PFG_SECOND_OBJECTIVE
+        PFG_WEIGHTED_SUM
+        PFG_NORMALIZED_NORMAL_CONSTRAINT
+        PFG_NORMAL_BOUNDARY_INTERSECTION
+        PFG_ENHANCED_NORMALIZED_NORMAL_CONSTRAINT
+        PFG_EPSILON_CONSTRAINT
+        PFG_UNKNOWN
 
     cdef enum PrintScheme:
         PS_DEFAULT
@@ -190,8 +202,10 @@ cdef extern from 'acado/ocp/ocp.hpp' namespace 'ACADO':
         returnValue minimizeMayerTerm(const Expression&)
         returnValue minimizeLagrangeTerm(const Expression&)
 
-        returnValue subjectTo( const DifferentialEquation&)
-        returnValue subjectTo( int, const ConstraintComponent&)
+        returnValue subjectTo(const DifferentialEquation&)
+        returnValue subjectTo(int, const ConstraintComponent&)
+
+        int getNumberOfMayerTerms()
 
 cdef extern from "<iostream>" namespace "std":
     cdef cppclass ostream:
@@ -221,3 +235,15 @@ cdef extern from 'acado/optimization_algorithm/optimization_algorithm.hpp' names
         returnValue getDifferentialStates(VariablesGrid&)
         returnValue getParameters(VariablesGrid&)
         returnValue getControls(VariablesGrid&)
+
+cdef extern from 'acado/optimization_algorithm/multi_objective_algorithm.hpp' namespace 'ACADO':
+    cdef cppclass MultiObjectiveAlgorithm(OptimizationAlgorithm):
+        MultiObjectiveAlgorithm()
+        MultiObjectiveAlgorithm(const OCP&)
+
+        returnValue solve() except+
+
+        returnValue getWeights(const char*)
+        returnValue getAllDifferentialStates(const char*)
+        returnValue getAllControls(const char*)
+        returnValue getAllParameters(const char*)

--- a/acadopy/api.pxd
+++ b/acadopy/api.pxd
@@ -56,3 +56,6 @@ cdef class VariablesGrid:
 cdef class OptimizationAlgorithm:
     cdef acado.OptimizationAlgorithm* _thisptr
     cdef bool _owner
+
+cdef class MultiObjectiveAlgorithm(OptimizationAlgorithm):
+    pass

--- a/acadopy/tests/test_acado.py
+++ b/acadopy/tests/test_acado.py
@@ -200,6 +200,26 @@ class AcadoTestCase(unittest.TestCase):
 
         self.assertIsInstance(result, ConstraintComponent)
 
+    def test_ocp_state(self):
+        """ Run the start of the car_ws example and test that the OCP
+        is set up correctly.
+        """
+
+        t1 = Parameter()
+        x1 = DifferentialState()
+        x2 = DifferentialState()
+        u = Control()
+
+        f = DifferentialEquation(0, t1)
+        f << dot(x1) == x2
+        f << dot(x2) == u
+
+        ocp = OCP(0, t1, 50)
+        ocp.minimizeMayerTerm(x2)
+        self.assertEqual(ocp.get_number_of_mayer_terms, 1)
+        ocp.minimizeMayerTerm(x2)
+        self.assertEqual(ocp.get_number_of_mayer_terms, 2)
+
     def test_rocket_flight(self):
         """ Test rocket flight example. """
         import os

--- a/acadopy/tests/test_acado.py
+++ b/acadopy/tests/test_acado.py
@@ -8,7 +8,7 @@ from acadopy.api import (
     exp, DMatrix, DVector, DifferentialEquation, dot, Control, OCP,
     AT_START, AT_END, OptimizationAlgorithm, HESSIAN_APPROXIMATION,
     EXACT_HESSIAN, MAX_NUM_ITERATIONS, KKT_TOLERANCE, SUCCESSFUL_RETURN,
-    clear_static_counters, ConstraintComponent
+    clear_static_counters, ConstraintComponent, Parameter
 )
 
 
@@ -40,7 +40,6 @@ class AcadoTestCase(unittest.TestCase):
 
         f = Function()
         self.assertIsInstance(f, Function)
-
 
     def test_expression_add(self):
 
@@ -113,10 +112,15 @@ class AcadoTestCase(unittest.TestCase):
     def test_simple_function(self):
         x = DifferentialState()
         z = IntermediateState()
-        t =TIME()
-        f= Function()
+        t = TIME()
+        f = Function()
 
         z = 0.5 * x + 1.0
+
+    def test_differentialstate_init(self):
+
+        x = DifferentialState('x')
+        x = DifferentialState('y', 0, 1)
 
     def test_differentialstate_equal(self):
 
@@ -145,6 +149,16 @@ class AcadoTestCase(unittest.TestCase):
         self.assertEqual(result.n, 0)
         self.assertEqual(result.nx, 2)
         self.assertEqual(result.nu, 0)
+
+    def test_differentialequation_init(self):
+        start = Parameter()
+        end = Parameter()
+        f = DifferentialEquation()
+        f = DifferentialEquation(0, 10)
+        f = DifferentialEquation(0.0, 10.0)
+        f = DifferentialEquation(start, end)
+        f = DifferentialEquation(start, 10.0)
+        f = DifferentialEquation(0.0, end)
 
     def test_dmatrix(self):
 

--- a/examples/car_ws.py
+++ b/examples/car_ws.py
@@ -1,0 +1,53 @@
+# (C) Copyright 2019 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+import os
+import sys
+
+from acadopy.api import (
+    DifferentialState, Control, Parameter, DifferentialEquation, dot, OCP,
+    AT_START, AT_END, MultiObjectiveAlgorithm, PFG_WEIGHTED_SUM,
+    PARETO_FRONT_GENERATION, PARETO_FRONT_DISCRETIZATION, KKT_TOLERANCE
+)
+
+
+x1 = DifferentialState()
+x2 = DifferentialState()
+t1 = Parameter()
+u = Control()
+
+f = DifferentialEquation(0, t1)
+
+f << dot(x1) == x2
+f << dot(x2) == u
+
+ocp = OCP(0.0, t1, 25)
+
+ocp.minimizeMayerTerm(x2)
+print('mayer num', ocp.get_number_of_mayer_terms())
+ocp.minimizeMayerTerm(2.0 * t1 / 20.0)
+print('mayer num', ocp.get_number_of_mayer_terms())
+
+ocp.subjectTo(f)
+print('mayer num', ocp.get_number_of_mayer_terms())
+
+ocp.subjectTo(AT_START, x1 == 0.0)
+ocp.subjectTo(AT_START, x2 == 0.0)
+ocp.subjectTo(AT_END, x1 == 200.0)
+
+ocp.subjectTo(0.0 <= x1 <= 200.001)
+ocp.subjectTo(0.0 <= x2 <= 40.0)
+ocp.subjectTo(0.0 <= u <= 5.0)
+ocp.subjectTo(0.0 <= t1 <= 50.0)
+
+algorithm = MultiObjectiveAlgorithm(ocp)
+# algorithm.set(PARETO_FRONT_GENERATION, PFG_WEIGHTED_SUM)
+# algorithm.set(PARETO_FRONT_DISCRETIZATION, 11)
+# algorithm.set(KKT_TOLERANCE, 1e-8 )
+
+print('solving')
+
+algorithm.solve()
+
+print('solved')
+# algorithm.get_all_differential_states('car_ws_stats.txt')


### PR DESCRIPTION
Currently still experiencing issues with the state of objects not being correctly updated: this time its the integer that stores the number of Mayer terms not being updated when `minimizeMayerTerm` is called. This causes the provided `examples/car_ws.py` to segfault as the optimizer thinks it has no objectives.